### PR TITLE
refactor(ci): simplify deploy workflow to release management

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,29 +1,14 @@
-name: Deploy to Production
+name: Release Management
 
 on:
   push:
-    branches: [master, main]
     tags:
       - 'v*'
 
-  workflow_dispatch:
-    inputs:
-      environment:
-        description: 'Environment to deploy to'
-        required: true
-        default: 'staging'
-        type: choice
-        options:
-          - staging
-          - production
-
 jobs:
-  deploy-backend:
-    name: Deploy Backend
+  quick-validation:
+    name: Quick Validation
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' || github.event.inputs.environment == 'production'
-    env:
-      DATABASE_URL: ${{ secrets.DATABASE_URL || 'postgresql://sgcv2_user:sgcv2_password@localhost:5432/sgcv2_test' }}
 
     steps:
       - name: Checkout code
@@ -42,96 +27,24 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+
+      - name: Build all packages
+        run: pnpm run build
         env:
-          # This should be a secret in a real environment
           DATABASE_URL: postgresql://sgcv2_user:sgcv2_password@localhost:5432/sgcv2_test
+          NEXT_PUBLIC_API_URL: http://localhost:3000
 
-      - name: Build shared package first
-        run: pnpm --filter @sgcv2/shared build
-
-      - name: Generate Prisma client
-        run: pnpm prisma:generate
-
-      - name: Build
-        run: pnpm run build:backend
-
-      - name: Deploy notification
+      - name: Validation success
         run: |
-          echo "🚀 Backend deployment would happen here"
-          echo "Environment: ${{ github.event.inputs.environment || 'production' }}"
-          echo "Version: ${{ github.ref_name }}"
-
-      # Uncomment and configure for your deployment platform
-      # - name: Deploy to Heroku
-      #   uses: akhileshns/heroku-deploy@v3.12.14
-      #   with:
-      #     heroku_api_key: ${{ secrets.HEROKU_API_KEY }}
-      #     heroku_app_name: "sgcv2-backend"
-      #     heroku_email: "your-email@example.com"
-
-      # - name: Deploy to Railway
-      #   run: |
-      #     npm install -g @railway/cli
-      #     railway up --service backend
-      #   env:
-      #     RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
-
-  deploy-frontend:
-    name: Deploy Frontend
-    runs-on: ubuntu-latest
-    if: github.event_name == 'push' || github.event.inputs.environment == 'production'
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 9
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          cache: 'pnpm'
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-        env:
-          # This should be a secret in a real environment
-          DATABASE_URL: postgresql://sgcv2_user:sgcv2_password@localhost:5432/sgcv2_test
-
-      - name: Build shared package first
-        run: pnpm --filter @sgcv2/shared build
-
-      - name: Build
-        run: pnpm run build:frontend
-        env:
-          NEXT_PUBLIC_API_URL: ${{ secrets.API_URL }}
-
-      - name: Deploy notification
-        run: |
-          echo "🚀 Frontend deployment would happen here"
-          echo "Environment: ${{ github.event.inputs.environment || 'production' }}"
-          echo "Version: ${{ github.ref_name }}"
-
-      # Uncomment and configure for Vercel
-      # - name: Deploy to Vercel
-      #   uses: amondnet/vercel-action@v25
-      #   with:
-      #     vercel-token: ${{ secrets.VERCEL_TOKEN }}
-      #     vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
-      #     vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
-      #     working-directory: ./frontend
+          echo "✅ Build validation passed"
+          echo "Tag: ${{ github.ref_name }}"
 
   create-release:
     name: Create GitHub Release
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: startsWith(github.ref, 'refs/tags/v')
-    needs: [deploy-backend, deploy-frontend]
+    needs: [quick-validation]
 
     steps:
       - name: Checkout code
@@ -140,13 +53,10 @@ jobs:
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ github.ref_name }}
-          name: Release ${{ github.ref_name }}
+          tag_name: "${{ github.ref_name }}"
+          name: "Release ${{ github.ref_name }}"
           body: |
             ## Changes in this Release
-            
-            - Backend deployed ✅
-            - Frontend deployed ✅
             
             See the [CHANGELOG](CHANGELOG.md) for details.
           draft: false

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,6 +22,8 @@ jobs:
     name: Deploy Backend
     runs-on: ubuntu-latest
     if: github.event_name == 'push' || github.event.inputs.environment == 'production'
+    env:
+      DATABASE_URL: ${{ secrets.DATABASE_URL || 'postgresql://sgcv2_user:sgcv2_password@localhost:5432/sgcv2_test' }}
 
     steps:
       - name: Checkout code
@@ -49,13 +51,9 @@ jobs:
 
       - name: Generate Prisma client
         run: pnpm prisma:generate
-        env:
-          DATABASE_URL: ${{ secrets.DATABASE_URL || 'postgresql://sgcv2_user:sgcv2_password@localhost:5432/sgcv2_test' }}
 
       - name: Build
         run: pnpm run build:backend
-        env:
-          DATABASE_URL: ${{ secrets.DATABASE_URL || 'postgresql://sgcv2_user:sgcv2_password@localhost:5432/sgcv2_test' }}
 
       - name: Deploy notification
         run: |
@@ -140,12 +138,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Create Release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.ref_name }}
-          release_name: Release ${{ github.ref_name }}
+          name: Release ${{ github.ref_name }}
           body: |
             ## Changes in this Release
             


### PR DESCRIPTION
## Description

This PR simplifies the deployment workflow to reflect its actual purpose: release management. The previous workflow had mock deployment jobs that didn't actually deploy anything, which was confusing and wasteful.

## Changes

- **Renamed workflow**: From "Deploy to Production" to "Release Management"
- **Removed mock jobs**: Eliminated `deploy-backend` and `deploy-frontend` jobs that only printed messages
- **Added validation**: New `quick-validation` job that builds all packages before creating a release
- **Simplified triggers**: Now only triggers on version tags (`v*`), not on every push to main
- **Removed undefined secrets**: No longer references `DATABASE_URL` or `API_URL` secrets that aren't configured
- **Consolidated build**: Single build step instead of separate backend/frontend builds

## Why?

The original workflow was misleading - it claimed to deploy but actually just printed messages. Since we don't have deployment infrastructure yet, this version is more honest about what it does: it validates that tagged code builds successfully, then creates a GitHub Release.

## Benefits

✅ No more context access warnings for undefined secrets
✅ Prevents creating releases from broken code
✅ Clearer intent and reduced confusion
✅ Faster execution (single build instead of two)
✅ Easy to extend when real deployment is added

## Testing

- [ ] Workflow syntax is valid (will be verified by GitHub Actions on merge)
- [ ] Will test with a version tag after merge

---

Related to version management improvements in commits:
- a2cd8af refactor(ci): simplify deploy workflow to release management
- 96db480 ci: resolve DATABASE_URL context warnings
- f3dd0ec chore: rollback version to 0.4.0