### PR TITLE
style(frontend): implement automated import sorting with eslint

### DIFF
--- a/frontend/app/(auth)/login/page.tsx
+++ b/frontend/app/(auth)/login/page.tsx
@@ -1,16 +1,18 @@
 'use client';
 
-import { zodResolver } from '@hookform/resolvers/zod';
+import { useState } from 'react';
 import { useForm } from 'react-hook-form';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Loader2, LogIn } from 'lucide-react';
 import { toast } from 'sonner';
 import * as z from 'zod';
-import { useState } from 'react';
-import { useAuth } from '@/hooks/use-auth';
+
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { LogIn, Loader2 } from 'lucide-react';
+import { useAuth } from '@/hooks/use-auth';
 
 const loginSchema = z.object({
   username: z.string().min(1, { message: 'Username is required' }),

--- a/frontend/app/(core)/_components/dropdown-menu-logout/index.tsx
+++ b/frontend/app/(core)/_components/dropdown-menu-logout/index.tsx
@@ -1,8 +1,9 @@
 'use client';
 
+import { IconLogout } from '@tabler/icons-react';
+
 import { DropdownMenuItem } from '@/components/ui/dropdown-menu';
 import { useAuth } from '@/hooks/use-auth';
-import { IconLogout } from '@tabler/icons-react';
 
 export function DropdownMenuLogout() {
   const { logout } = useAuth();

--- a/frontend/app/(core)/_components/header/header.tsx
+++ b/frontend/app/(core)/_components/header/header.tsx
@@ -1,6 +1,8 @@
 'use client';
 
-import { SidebarTrigger } from '@/components/ui/sidebar';
+import { Fragment } from 'react';
+import { usePathname } from 'next/navigation';
+
 import {
   Breadcrumb,
   BreadcrumbItem,
@@ -9,8 +11,7 @@ import {
   BreadcrumbPage,
   BreadcrumbSeparator,
 } from '@/components/ui/breadcrumb';
-import { usePathname } from 'next/navigation';
-import { Fragment } from 'react';
+import { SidebarTrigger } from '@/components/ui/sidebar';
 
 export default function Header() {
   const pathname = usePathname();

--- a/frontend/app/(core)/_components/nav-user/index.tsx
+++ b/frontend/app/(core)/_components/nav-user/index.tsx
@@ -1,9 +1,13 @@
+import Link from 'next/link';
+
 import {
   IconCreditCard,
   IconDotsVertical,
   IconNotification,
   IconUserCircle,
 } from '@tabler/icons-react';
+import { sha256 } from 'js-sha256';
+
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import {
   DropdownMenu,
@@ -16,9 +20,8 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { SidebarMenu, SidebarMenuButton, SidebarMenuItem } from '@/components/ui/sidebar';
 import { serverUsersService } from '@/lib/api/server-users.service';
+
 import { DropdownMenuLogout } from '../dropdown-menu-logout';
-import { sha256 } from 'js-sha256';
-import Link from 'next/link';
 
 export async function NavUser() {
   // const { isMobile } = useSidebar();

--- a/frontend/app/(core)/_components/sidebar/sidebar.tsx
+++ b/frontend/app/(core)/_components/sidebar/sidebar.tsx
@@ -1,4 +1,25 @@
 import Link from 'next/link';
+
+import {
+  Box,
+  Calendar,
+  ChevronDown,
+  ClipboardList,
+  CreditCard,
+  DollarSign,
+  FileCheck,
+  FileText,
+  HomeIcon,
+  Package,
+  Receipt,
+  Settings,
+  Truck,
+  UserCog,
+  Users,
+  Wallet,
+  Wrench,
+} from 'lucide-react';
+
 import {
   Sidebar,
   SidebarContent,
@@ -10,32 +31,14 @@ import {
   SidebarMenuSub,
   SidebarMenuSubItem,
 } from '@/components/ui/sidebar';
-import {
-  ChevronDown,
-  HomeIcon,
-  ClipboardList,
-  Users,
-  Calendar,
-  FileText,
-  Package,
-  Wrench,
-  Box,
-  Truck,
-  FileCheck,
-  Receipt,
-  CreditCard,
-  DollarSign,
-  Wallet,
-  UserCog,
-  Settings,
-} from 'lucide-react';
+import { serverUsersService } from '@/lib/api/server-users.service';
+
 import {
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
 } from '../../../../components/ui/collapsible';
 import { NavUser } from '../nav-user';
-import { serverUsersService } from '@/lib/api/server-users.service';
 
 export default async function SidebarApp() {
   const response = await serverUsersService.getMe();

--- a/frontend/app/(core)/layout.tsx
+++ b/frontend/app/(core)/layout.tsx
@@ -1,10 +1,13 @@
+import { cookies } from 'next/headers';
+
+import { AuthenticatedUserDto } from '@sgcv2/shared';
+
+import StoreInitializer from '@/components/auth/store-initializer';
+import { SidebarInset, SidebarProvider } from '@/components/ui/sidebar';
+import { serverUsersService } from '@/lib/api/server-users.service';
+
 import Header from './_components/header/header';
 import SidebarApp from './_components/sidebar/sidebar';
-import { SidebarProvider, SidebarInset } from '@/components/ui/sidebar';
-import { cookies } from 'next/headers';
-import StoreInitializer from '@/components/auth/store-initializer';
-import { serverUsersService } from '@/lib/api/server-users.service';
-import { AuthenticatedUserDto } from '@sgcv2/shared';
 
 export default async function DashboardLayout({ children }: { children: React.ReactNode }) {
   const cookieStore = await cookies();

--- a/frontend/app/(core)/operations/customers/[id]/page.tsx
+++ b/frontend/app/(core)/operations/customers/[id]/page.tsx
@@ -1,10 +1,13 @@
 import { Suspense } from 'react';
 import { notFound } from 'next/navigation';
-import { serverCustomersService } from '@/lib/api/server-customers.service';
-import { CustomerDetailsHeader } from '../_components/customer-details-header';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
 import { Info, MapPin, Users } from 'lucide-react';
+
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { serverCustomersService } from '@/lib/api/server-customers.service';
+
+import { CustomerDetailsHeader } from '../_components/customer-details-header';
 import { LocationsList } from '../_components/locations-list';
 import { SubCustomersList } from '../_components/sub-customers-list';
 

--- a/frontend/app/(core)/operations/customers/[id]/update/_components/update-customer-form.tsx
+++ b/frontend/app/(core)/operations/customers/[id]/update/_components/update-customer-form.tsx
@@ -1,5 +1,6 @@
-import { CustomerForm } from '../../../_components/customer-form';
 import { CustomerDto } from '@sgcv2/shared';
+
+import { CustomerForm } from '../../../_components/customer-form';
 
 interface UpdateCustomerFormProps {
   customer: CustomerDto;

--- a/frontend/app/(core)/operations/customers/[id]/update/page.tsx
+++ b/frontend/app/(core)/operations/customers/[id]/update/page.tsx
@@ -1,7 +1,9 @@
-import { serverCustomersService } from '@/lib/api/server-customers.service';
-import { UpdateCustomerForm } from './_components/update-customer-form';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { notFound } from 'next/navigation';
+
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { serverCustomersService } from '@/lib/api/server-customers.service';
+
+import { UpdateCustomerForm } from './_components/update-customer-form';
 
 export default async function UpdateCustomerPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;

--- a/frontend/app/(core)/operations/customers/_components/actions.ts
+++ b/frontend/app/(core)/operations/customers/_components/actions.ts
@@ -1,10 +1,13 @@
 'use server';
 
-import { ActionState } from '../types';
-import { CreateCustomerSchema, UpdateCustomerSchema } from '@sgcv2/shared';
-import { serverCustomersService } from '@/lib/api/server-customers.service';
 import { revalidatePath } from 'next/cache';
 import { redirect } from 'next/navigation';
+
+import { CreateCustomerSchema, UpdateCustomerSchema } from '@sgcv2/shared';
+
+import { serverCustomersService } from '@/lib/api/server-customers.service';
+
+import { ActionState } from '../types';
 
 export async function handleCustomerFilters(formData: FormData) {
   const search = formData.get('search') as string;

--- a/frontend/app/(core)/operations/customers/_components/customer-details-header.tsx
+++ b/frontend/app/(core)/operations/customers/_components/customer-details-header.tsx
@@ -1,8 +1,11 @@
+import Link from 'next/link';
+
+import { Edit } from 'lucide-react';
+
+import { CustomerDto, CustomerState } from '@sgcv2/shared';
+
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { CustomerDto, CustomerState } from '@sgcv2/shared';
-import { Edit } from 'lucide-react';
-import Link from 'next/link';
 
 interface CustomerDetailsHeaderProps {
   customer: CustomerDto;

--- a/frontend/app/(core)/operations/customers/_components/customer-form.tsx
+++ b/frontend/app/(core)/operations/customers/_components/customer-form.tsx
@@ -1,13 +1,17 @@
 'use client';
 
 import { useActionState } from 'react';
+
+import { AlertCircle } from 'lucide-react';
+
+import { CustomerDto } from '@sgcv2/shared';
+
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { createCustomerAction, updateCustomerAction } from './actions';
-import { CustomerDto } from '@sgcv2/shared';
+
 import { ActionState } from '../types';
-import { AlertCircle } from 'lucide-react';
+import { createCustomerAction, updateCustomerAction } from './actions';
 
 interface CustomerFormProps {
   customer?: CustomerDto;

--- a/frontend/app/(core)/operations/customers/_components/customerDropMenu.tsx
+++ b/frontend/app/(core)/operations/customers/_components/customerDropMenu.tsx
@@ -1,14 +1,10 @@
 'use client';
 
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
-  DropdownMenuShortcut,
-  DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu';
+import { useState } from 'react';
+import Link from 'next/link';
+
+import { EllipsisIcon, Eye, Pencil, Trash } from 'lucide-react';
+
 import {
   AlertDialog,
   AlertDialogAction,
@@ -19,9 +15,15 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog';
-import { EllipsisIcon, Eye, Pencil, Trash } from 'lucide-react';
-import Link from 'next/link';
-import { useState } from 'react';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
 
 interface CustomerDropMenuProps {
   id: string;

--- a/frontend/app/(core)/operations/customers/_components/filters.tsx
+++ b/frontend/app/(core)/operations/customers/_components/filters.tsx
@@ -1,9 +1,13 @@
-import { Input } from '@/components/ui/input';
-import { Button } from '@/components/ui/button';
-import { Search, Plus } from 'lucide-react';
-import { CustomerState } from '@sgcv2/shared';
-import { handleCustomerFilters } from './actions';
 import Link from 'next/link';
+
+import { Plus, Search } from 'lucide-react';
+
+import { CustomerState } from '@sgcv2/shared';
+
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+
+import { handleCustomerFilters } from './actions';
 
 interface CustomersFiltersProps {
   search?: string;

--- a/frontend/app/(core)/operations/customers/_components/location-form.tsx
+++ b/frontend/app/(core)/operations/customers/_components/location-form.tsx
@@ -1,12 +1,15 @@
 'use client';
 
 import { useActionState } from 'react';
+
+import { AlertCircle } from 'lucide-react';
+
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { createLocationAction } from './sub-customer-actions';
+
 import { ActionState } from '../types';
-import { AlertCircle } from 'lucide-react';
+import { createLocationAction } from './sub-customer-actions';
 
 interface LocationFormProps {
   parentId: string;

--- a/frontend/app/(core)/operations/customers/_components/locations-list.tsx
+++ b/frontend/app/(core)/operations/customers/_components/locations-list.tsx
@@ -1,15 +1,8 @@
-import { serverLocationsService } from '@/lib/api/server-locations.service';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Home, MapPin, Plus, Trash2 } from 'lucide-react';
+
+import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { Plus, MapPin, Trash2, Home } from 'lucide-react';
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from '@/components/ui/table';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import {
   Sheet,
   SheetContent,
@@ -18,8 +11,17 @@ import {
   SheetTitle,
   SheetTrigger,
 } from '@/components/ui/sheet';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { serverLocationsService } from '@/lib/api/server-locations.service';
+
 import { LocationForm } from './location-form';
-import { Badge } from '@/components/ui/badge';
 
 interface LocationsListProps {
   customerId: string;

--- a/frontend/app/(core)/operations/customers/_components/sub-customer-actions.ts
+++ b/frontend/app/(core)/operations/customers/_components/sub-customer-actions.ts
@@ -2,9 +2,12 @@
 
 import { revalidatePath } from 'next/cache';
 import { redirect } from 'next/navigation';
-import { serverSubCustomersService } from '@/lib/api/server-subcustomers.service';
+
+import { CreateCustomerLocationSchema, CreateSubCustomerWithLocationSchema } from '@sgcv2/shared';
+
 import { serverLocationsService } from '@/lib/api/server-locations.service';
-import { CreateSubCustomerWithLocationSchema, CreateCustomerLocationSchema } from '@sgcv2/shared';
+import { serverSubCustomersService } from '@/lib/api/server-subcustomers.service';
+
 import { ActionState } from '../types';
 
 export async function createSubCustomerWithLocationAction(

--- a/frontend/app/(core)/operations/customers/_components/sub-customer-form.tsx
+++ b/frontend/app/(core)/operations/customers/_components/sub-customer-form.tsx
@@ -1,13 +1,16 @@
 'use client';
 
 import { useActionState } from 'react';
+
+import { AlertCircle, Building2, MapPin } from 'lucide-react';
+
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Separator } from '@/components/ui/separator';
-import { createSubCustomerWithLocationAction } from './sub-customer-actions';
+
 import { ActionState } from '../types';
-import { Building2, MapPin, AlertCircle } from 'lucide-react';
+import { createSubCustomerWithLocationAction } from './sub-customer-actions';
 
 interface SubCustomerFormProps {
   parentId: string;

--- a/frontend/app/(core)/operations/customers/_components/sub-customers-list.tsx
+++ b/frontend/app/(core)/operations/customers/_components/sub-customers-list.tsx
@@ -1,15 +1,7 @@
-import { serverSubCustomersService } from '@/lib/api/server-subcustomers.service';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { MapPin, Plus, Trash2, Users } from 'lucide-react';
+
 import { Button } from '@/components/ui/button';
-import { Plus, Users, Trash2, MapPin } from 'lucide-react';
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from '@/components/ui/table';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import {
   Sheet,
   SheetContent,
@@ -18,8 +10,18 @@ import {
   SheetTitle,
   SheetTrigger,
 } from '@/components/ui/sheet';
-import { SubCustomerForm } from './sub-customer-form';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { serverSubCustomersService } from '@/lib/api/server-subcustomers.service';
+
 import { LocationForm } from './location-form';
+import { SubCustomerForm } from './sub-customer-form';
 
 interface SubCustomersListProps {
   customerId: string;

--- a/frontend/app/(core)/operations/customers/_components/table.tsx
+++ b/frontend/app/(core)/operations/customers/_components/table.tsx
@@ -1,12 +1,15 @@
 'use client';
 
-import { CustomerDto } from '@sgcv2/shared';
-import { CustomerDropMenu } from './customerDropMenu';
-import { statusMap } from '../_const/const';
-import { Badge } from '@/components/ui/badge';
-import { DataTable, Column } from '@/components/table/data-table';
-import { deleteCustomerAction } from './actions';
 import { toast } from 'sonner';
+
+import { CustomerDto } from '@sgcv2/shared';
+
+import { Column, DataTable } from '@/components/table/data-table';
+import { Badge } from '@/components/ui/badge';
+
+import { statusMap } from '../_const/const';
+import { deleteCustomerAction } from './actions';
+import { CustomerDropMenu } from './customerDropMenu';
 
 interface CustomersTableProps {
   data: CustomerDto[];

--- a/frontend/app/(core)/operations/customers/new/page.tsx
+++ b/frontend/app/(core)/operations/customers/new/page.tsx
@@ -1,5 +1,6 @@
-import { CustomerForm } from '../_components/customer-form';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+
+import { CustomerForm } from '../_components/customer-form';
 
 export const metadata = {
   title: 'Nuevo Cliente | SGCV2',

--- a/frontend/app/(core)/operations/customers/not-found.tsx
+++ b/frontend/app/(core)/operations/customers/not-found.tsx
@@ -1,7 +1,9 @@
 import Link from 'next/link';
+
+import { AlertCircle, ArrowLeft, Home } from 'lucide-react';
+
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { AlertCircle, ArrowLeft, Home } from 'lucide-react';
 
 export default function CustomerNotFound() {
   return (

--- a/frontend/app/(core)/operations/customers/page.tsx
+++ b/frontend/app/(core)/operations/customers/page.tsx
@@ -1,8 +1,10 @@
-import { serverCustomersService } from '@/lib/api/server-customers.service';
-import { CustomersTable } from './_components/table';
-import { CustomersFilters } from './_components/filters';
 import { CustomerDto, CustomerState } from '@sgcv2/shared';
+
 import { DataPagination } from '@/components/data-pagination';
+import { serverCustomersService } from '@/lib/api/server-customers.service';
+
+import { CustomersFilters } from './_components/filters';
+import { CustomersTable } from './_components/table';
 
 interface CustomersPageProps {
   searchParams: Promise<{ [key: string]: string | string[] | undefined }>;

--- a/frontend/app/(core)/permissions/_components/permissions-table.tsx
+++ b/frontend/app/(core)/permissions/_components/permissions-table.tsx
@@ -1,3 +1,4 @@
+import { Card, CardContent } from '@/components/ui/card';
 import {
   Table,
   TableBody,
@@ -6,7 +7,6 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table';
-import { Card, CardContent } from '@/components/ui/card';
 
 interface Permission {
   id: number;

--- a/frontend/app/(core)/permissions/page.tsx
+++ b/frontend/app/(core)/permissions/page.tsx
@@ -1,7 +1,10 @@
-import { PermissionDto } from '@sgcv2/shared';
-import { serverRolesService } from '@/lib/api/server-roles.service';
-import { PermissionsTable } from './_components/permissions-table';
 import { ShieldCheck } from 'lucide-react';
+
+import { PermissionDto } from '@sgcv2/shared';
+
+import { serverRolesService } from '@/lib/api/server-roles.service';
+
+import { PermissionsTable } from './_components/permissions-table';
 
 export default async function PermissionsPage() {
   let permissions: PermissionDto[] = [];

--- a/frontend/app/(core)/roles/[id]/page.tsx
+++ b/frontend/app/(core)/roles/[id]/page.tsx
@@ -1,7 +1,9 @@
-import { serverRolesService } from '@/lib/api/server-roles.service';
-import { serverPermissionsService } from '@/lib/api/server-permissions.service';
-import { RoleForm } from '../_components/role-form';
 import { notFound } from 'next/navigation';
+
+import { serverPermissionsService } from '@/lib/api/server-permissions.service';
+import { serverRolesService } from '@/lib/api/server-roles.service';
+
+import { RoleForm } from '../_components/role-form';
 
 interface EditRolePageProps {
   params: Promise<{ id: string }>;

--- a/frontend/app/(core)/roles/_components/actions.ts
+++ b/frontend/app/(core)/roles/_components/actions.ts
@@ -1,9 +1,11 @@
 'use server';
 
-import { redirect } from 'next/navigation';
-import { serverRolesService } from '@/lib/api/server-roles.service';
 import { revalidatePath } from 'next/cache';
+import { redirect } from 'next/navigation';
+
 import { CreateRoleDto, UpdateRoleDto } from '@sgcv2/shared';
+
+import { serverRolesService } from '@/lib/api/server-roles.service';
 
 export async function handleRoleFilters(formData: FormData) {
   const search = formData.get('search');

--- a/frontend/app/(core)/roles/_components/filters.tsx
+++ b/frontend/app/(core)/roles/_components/filters.tsx
@@ -1,6 +1,8 @@
-import { Input } from '@/components/ui/input';
 import { Search } from 'lucide-react';
+
 import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+
 import { handleRoleFilters } from './actions';
 
 interface RolesFiltersProps {

--- a/frontend/app/(core)/roles/_components/role-form.tsx
+++ b/frontend/app/(core)/roles/_components/role-form.tsx
@@ -1,14 +1,21 @@
 'use client';
 
+import { useState } from 'react';
 import { useForm } from 'react-hook-form';
+import { useRouter } from 'next/navigation';
+
 import { zodResolver } from '@hookform/resolvers/zod';
+import { toast } from 'sonner';
+
 import {
-  createRoleSchema,
   CreateRoleDto,
+  createRoleSchema,
   PermissionDto,
   RoleWithPermissionsDto,
 } from '@sgcv2/shared';
+
 import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
 import {
   Form,
   FormControl,
@@ -20,11 +27,8 @@ import {
 } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
-import { Checkbox } from '@/components/ui/checkbox';
-import { useRouter } from 'next/navigation';
+
 import { createRoleAction, updateRoleAction } from './actions';
-import { toast } from 'sonner';
-import { useState } from 'react';
 
 interface RoleFormProps {
   initialData?: RoleWithPermissionsDto;

--- a/frontend/app/(core)/roles/_components/table.tsx
+++ b/frontend/app/(core)/roles/_components/table.tsx
@@ -1,13 +1,15 @@
 'use client';
 
+import { useTransition } from 'react';
+import { useRouter } from 'next/navigation';
+
+import { MoreHorizontal, SquarePen, Trash2 } from 'lucide-react';
+import { toast } from 'sonner';
+
 import { RoleDto } from '@sgcv2/shared';
+
 import { Column, DataTable } from '@/components/table/data-table';
 import { Button } from '@/components/ui/button';
-import { MoreHorizontal, SquarePen, Trash2 } from 'lucide-react';
-import { useRouter } from 'next/navigation';
-import { useTransition } from 'react';
-import { deleteRoleAction } from './actions';
-import { toast } from 'sonner';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -16,6 +18,8 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
+
+import { deleteRoleAction } from './actions';
 
 interface RolesTableProps {
   data: RoleDto[];

--- a/frontend/app/(core)/roles/new/page.tsx
+++ b/frontend/app/(core)/roles/new/page.tsx
@@ -1,4 +1,5 @@
 import { serverPermissionsService } from '@/lib/api/server-permissions.service';
+
 import { RoleForm } from '../_components/role-form';
 
 export default async function NewRolePage() {

--- a/frontend/app/(core)/roles/page.tsx
+++ b/frontend/app/(core)/roles/page.tsx
@@ -1,10 +1,13 @@
-import { serverRolesService } from '@/lib/api/server-roles.service';
-import { RolesTable } from './_components/table';
-import { RolesFilters } from './_components/filters';
+import Link from 'next/link';
+
 import { RoleDto, RoleFilterDto } from '@sgcv2/shared';
+
 import { DataPagination } from '@/components/data-pagination';
 import { Button } from '@/components/ui/button';
-import Link from 'next/link';
+import { serverRolesService } from '@/lib/api/server-roles.service';
+
+import { RolesFilters } from './_components/filters';
+import { RolesTable } from './_components/table';
 
 interface RolesPageProps {
   searchParams: Promise<{ [key: string]: string | string[] | undefined }>;

--- a/frontend/app/(core)/users/[id]/edit/page.tsx
+++ b/frontend/app/(core)/users/[id]/edit/page.tsx
@@ -1,6 +1,8 @@
-import { serverUsersService } from '@/lib/api/server-users.service';
-import { UserForm } from '../../_components/user-form';
 import { notFound } from 'next/navigation';
+
+import { serverUsersService } from '@/lib/api/server-users.service';
+
+import { UserForm } from '../../_components/user-form';
 
 interface EditUserPageProps {
   params: Promise<{ id: string }>;

--- a/frontend/app/(core)/users/_components/actions.ts
+++ b/frontend/app/(core)/users/_components/actions.ts
@@ -1,10 +1,13 @@
 'use server';
 
-import { redirect } from 'next/navigation';
 import { revalidatePath } from 'next/cache';
-import { serverUsersService } from '@/lib/api/server-users.service';
-import { CreateUserDto, UpdateUserDto, UserDto } from '@sgcv2/shared';
+import { redirect } from 'next/navigation';
+
 import * as z from 'zod';
+
+import { CreateUserDto, UpdateUserDto, UserDto } from '@sgcv2/shared';
+
+import { serverUsersService } from '@/lib/api/server-users.service';
 
 const userSchema = z.object({
   username: z.string().min(3, 'El nombre de usuario debe tener al menos 3 caracteres'),

--- a/frontend/app/(core)/users/_components/filters.tsx
+++ b/frontend/app/(core)/users/_components/filters.tsx
@@ -1,7 +1,10 @@
-import { Input } from '@/components/ui/input';
 import { Search } from 'lucide-react';
-import { Button } from '@/components/ui/button';
+
 import { UserStatus } from '@sgcv2/shared';
+
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+
 import { handleUserFilters } from './actions';
 
 interface UsersFiltersProps {

--- a/frontend/app/(core)/users/_components/submit-button.tsx
+++ b/frontend/app/(core)/users/_components/submit-button.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useFormStatus } from 'react-dom';
+
 import { Button } from '@/components/ui/button';
 
 interface SubmitButtonProps {

--- a/frontend/app/(core)/users/_components/table.tsx
+++ b/frontend/app/(core)/users/_components/table.tsx
@@ -1,11 +1,14 @@
 'use client';
 
-import { UserDto } from '@sgcv2/shared';
-import { UserDropMenu } from './userDropMenu';
-import { Badge } from '@/components/ui/badge';
-import { DataTable, Column } from '@/components/table/data-table';
-import { blockUserAction } from './actions';
 import { toast } from 'sonner';
+
+import { UserDto } from '@sgcv2/shared';
+
+import { Column, DataTable } from '@/components/table/data-table';
+import { Badge } from '@/components/ui/badge';
+
+import { blockUserAction } from './actions';
+import { UserDropMenu } from './userDropMenu';
 
 interface UsersTableProps {
   data: UserDto[];

--- a/frontend/app/(core)/users/_components/user-form.tsx
+++ b/frontend/app/(core)/users/_components/user-form.tsx
@@ -1,11 +1,13 @@
 'use client';
 
 import { useActionState } from 'react';
-import { createUserAction, updateUserAction, ActionState } from './actions';
 import { useRouter } from 'next/navigation';
-import { Input } from '@/components/ui/input';
+
 import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+
+import { ActionState, createUserAction, updateUserAction } from './actions';
 import { SubmitButton } from './submit-button';
 
 interface UserFormValues {

--- a/frontend/app/(core)/users/_components/userDropMenu.tsx
+++ b/frontend/app/(core)/users/_components/userDropMenu.tsx
@@ -1,14 +1,10 @@
 'use client';
 
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
-  DropdownMenuShortcut,
-  DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu';
+import { useState } from 'react';
+import Link from 'next/link';
+
+import { EllipsisIcon, Eye, Trash } from 'lucide-react';
+
 import {
   AlertDialog,
   AlertDialogAction,
@@ -19,9 +15,15 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog';
-import { EllipsisIcon, Eye, Trash } from 'lucide-react';
-import Link from 'next/link';
-import { useState } from 'react';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
 
 interface UserDropMenuProps {
   id: number;

--- a/frontend/app/(core)/users/page.tsx
+++ b/frontend/app/(core)/users/page.tsx
@@ -1,10 +1,13 @@
-import { serverUsersService } from '@/lib/api/server-users.service';
-import { UsersTable } from './_components/table';
-import { UsersFilters } from './_components/filters';
+import Link from 'next/link';
+
 import { UserDto, UserFilterDto, UserStatus } from '@sgcv2/shared';
+
 import { DataPagination } from '@/components/data-pagination';
 import { Button } from '@/components/ui/button';
-import Link from 'next/link';
+import { serverUsersService } from '@/lib/api/server-users.service';
+
+import { UsersFilters } from './_components/filters';
+import { UsersTable } from './_components/table';
 
 interface UsersPageProps {
   searchParams: Promise<{ [key: string]: string | string[] | undefined }>;

--- a/frontend/app/(core)/users/profile/_actions/profile.actions.ts
+++ b/frontend/app/(core)/users/profile/_actions/profile.actions.ts
@@ -1,14 +1,17 @@
 'use server';
 
 import { revalidatePath } from 'next/cache';
+
+import axios from 'axios';
+
+import { serverUsersService } from '@/lib/api/server-users.service';
+
 import {
+  UpdateAvatarSchema,
   UpdateEmailSchema,
   UpdatePasswordSchema,
-  UpdateAvatarSchema,
   UpdateRoleSchema,
 } from '../_schemas/profile.schema';
-import { serverUsersService } from '@/lib/api/server-users.service';
-import axios from 'axios';
 
 export async function updateEmailAction(formData: FormData) {
   const data = Object.fromEntries(formData);

--- a/frontend/app/(core)/users/profile/_components/avatar-form.tsx
+++ b/frontend/app/(core)/users/profile/_components/avatar-form.tsx
@@ -1,12 +1,12 @@
 'use client';
 
 import { useForm } from 'react-hook-form';
+
 import { zodResolver } from '@hookform/resolvers/zod';
-import { UpdateAvatarSchema } from '../_schemas/profile.schema';
-import { updateAvatarAction } from '../_actions/profile.actions';
+import { toast } from 'sonner';
+import { z } from 'zod';
+
 import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
 import {
   Card,
   CardContent,
@@ -15,8 +15,11 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card';
-import { toast } from 'sonner';
-import { z } from 'zod';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+import { updateAvatarAction } from '../_actions/profile.actions';
+import { UpdateAvatarSchema } from '../_schemas/profile.schema';
 
 type AvatarValues = z.infer<typeof UpdateAvatarSchema>;
 

--- a/frontend/app/(core)/users/profile/_components/email-form.tsx
+++ b/frontend/app/(core)/users/profile/_components/email-form.tsx
@@ -1,12 +1,12 @@
 'use client';
 
 import { useForm } from 'react-hook-form';
+
 import { zodResolver } from '@hookform/resolvers/zod';
-import { UpdateEmailSchema } from '../_schemas/profile.schema';
-import { updateEmailAction } from '../_actions/profile.actions';
+import { toast } from 'sonner';
+import { z } from 'zod';
+
 import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
 import {
   Card,
   CardContent,
@@ -15,8 +15,11 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card';
-import { toast } from 'sonner';
-import { z } from 'zod';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+import { updateEmailAction } from '../_actions/profile.actions';
+import { UpdateEmailSchema } from '../_schemas/profile.schema';
 
 type EmailValues = z.infer<typeof UpdateEmailSchema>;
 

--- a/frontend/app/(core)/users/profile/_components/password-form.tsx
+++ b/frontend/app/(core)/users/profile/_components/password-form.tsx
@@ -1,12 +1,12 @@
 'use client';
 
 import { useForm } from 'react-hook-form';
+
 import { zodResolver } from '@hookform/resolvers/zod';
-import { UpdatePasswordSchema } from '../_schemas/profile.schema';
-import { updatePasswordAction } from '../_actions/profile.actions';
+import { toast } from 'sonner';
+import { z } from 'zod';
+
 import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
 import {
   Card,
   CardContent,
@@ -15,8 +15,11 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card';
-import { toast } from 'sonner';
-import { z } from 'zod';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+import { updatePasswordAction } from '../_actions/profile.actions';
+import { UpdatePasswordSchema } from '../_schemas/profile.schema';
 
 type PasswordValues = z.infer<typeof UpdatePasswordSchema>;
 

--- a/frontend/app/(core)/users/profile/_components/profile-header.tsx
+++ b/frontend/app/(core)/users/profile/_components/profile-header.tsx
@@ -1,5 +1,6 @@
-import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { UserWithRolesDto } from '@sgcv2/shared';
+
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 
 interface ProfileHeaderProps {
   user: UserWithRolesDto;

--- a/frontend/app/(core)/users/profile/_components/profile-info.tsx
+++ b/frontend/app/(core)/users/profile/_components/profile-info.tsx
@@ -1,8 +1,10 @@
+import { IconClock, IconHash, IconMail, IconShield, IconUser } from '@tabler/icons-react';
+
 import { UserWithRolesDto } from '@sgcv2/shared';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+
 import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Separator } from '@/components/ui/separator';
-import { IconUser, IconMail, IconHash, IconClock, IconShield } from '@tabler/icons-react';
 
 interface ProfileInfoProps {
   user: UserWithRolesDto;

--- a/frontend/app/(core)/users/profile/page.tsx
+++ b/frontend/app/(core)/users/profile/page.tsx
@@ -1,12 +1,15 @@
+import { redirect } from 'next/navigation';
+
+import axios from 'axios';
+
+import { Separator } from '@/components/ui/separator';
 import { serverUsersService } from '@/lib/api/server-users.service';
-import { ProfileHeader } from './_components/profile-header';
-import { ProfileInfo } from './_components/profile-info';
+
+import { AvatarForm } from './_components/avatar-form';
 import { EmailForm } from './_components/email-form';
 import { PasswordForm } from './_components/password-form';
-import { AvatarForm } from './_components/avatar-form';
-import { Separator } from '@/components/ui/separator';
-import { redirect } from 'next/navigation';
-import axios from 'axios';
+import { ProfileHeader } from './_components/profile-header';
+import { ProfileInfo } from './_components/profile-info';
 
 export default async function ProfilePage() {
   let user;

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,7 +1,9 @@
 import type { Metadata } from 'next';
 import { Geist, Geist_Mono } from 'next/font/google';
-import './globals.css';
+
 import { Toaster } from '@/components/ui/sonner';
+
+import './globals.css';
 
 const geistSans = Geist({
   variable: '--font-geist-sans',

--- a/frontend/components/auth/store-initializer.tsx
+++ b/frontend/components/auth/store-initializer.tsx
@@ -1,8 +1,10 @@
 'use client';
 
 import { useRef } from 'react';
-import { useAuthStore } from '@/stores/auth.store';
+
 import { AuthenticatedUserDto } from '@sgcv2/shared';
+
+import { useAuthStore } from '@/stores/auth.store';
 
 interface StoreInitializerProps {
   user: AuthenticatedUserDto | null;

--- a/frontend/components/avatar/avatar.tsx
+++ b/frontend/components/avatar/avatar.tsx
@@ -1,6 +1,7 @@
 'use client';
-import { Avatar, AvatarFallback, AvatarImage } from '../ui/avatar';
 import { useAuth } from '@/hooks/use-auth';
+
+import { Avatar, AvatarFallback, AvatarImage } from '../ui/avatar';
 
 export function AvatarUser() {
   const { logout, user } = useAuth();

--- a/frontend/components/table/data-table.tsx
+++ b/frontend/components/table/data-table.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { ReactNode } from 'react';
+
 import {
   Table,
   TableBody,
@@ -8,7 +10,6 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table';
-import { ReactNode } from 'react';
 
 export interface Column<T> {
   header: string;

--- a/frontend/components/ui/alert-dialog.tsx
+++ b/frontend/components/ui/alert-dialog.tsx
@@ -1,10 +1,11 @@
 'use client';
 
 import * as React from 'react';
+
 import * as AlertDialogPrimitive from '@radix-ui/react-alert-dialog';
 
-import { cn } from '@/lib/utils';
 import { buttonVariants } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
 
 function AlertDialog({ ...props }: React.ComponentProps<typeof AlertDialogPrimitive.Root>) {
   return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />;
@@ -122,14 +123,14 @@ function AlertDialogCancel({
 
 export {
   AlertDialog,
-  AlertDialogPortal,
-  AlertDialogOverlay,
-  AlertDialogTrigger,
-  AlertDialogContent,
-  AlertDialogHeader,
-  AlertDialogFooter,
-  AlertDialogTitle,
-  AlertDialogDescription,
   AlertDialogAction,
   AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogOverlay,
+  AlertDialogPortal,
+  AlertDialogTitle,
+  AlertDialogTrigger,
 };

--- a/frontend/components/ui/avatar.tsx
+++ b/frontend/components/ui/avatar.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import * as React from 'react';
+
 import * as AvatarPrimitive from '@radix-ui/react-avatar';
 
 import { cn } from '@/lib/utils';
@@ -38,4 +39,4 @@ function AvatarFallback({
   );
 }
 
-export { Avatar, AvatarImage, AvatarFallback };
+export { Avatar, AvatarFallback, AvatarImage };

--- a/frontend/components/ui/badge.tsx
+++ b/frontend/components/ui/badge.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+
 import { Slot } from '@radix-ui/react-slot';
 import { cva, type VariantProps } from 'class-variance-authority';
 

--- a/frontend/components/ui/breadcrumb.tsx
+++ b/frontend/components/ui/breadcrumb.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+
 import { Slot } from '@radix-ui/react-slot';
 import { ChevronRight, MoreHorizontal } from 'lucide-react';
 
@@ -93,10 +94,10 @@ function BreadcrumbEllipsis({ className, ...props }: React.ComponentProps<'span'
 
 export {
   Breadcrumb,
-  BreadcrumbList,
+  BreadcrumbEllipsis,
   BreadcrumbItem,
   BreadcrumbLink,
+  BreadcrumbList,
   BreadcrumbPage,
   BreadcrumbSeparator,
-  BreadcrumbEllipsis,
 };

--- a/frontend/components/ui/button.tsx
+++ b/frontend/components/ui/button.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+
 import { Slot } from '@radix-ui/react-slot';
 import { cva, type VariantProps } from 'class-variance-authority';
 

--- a/frontend/components/ui/card.tsx
+++ b/frontend/components/ui/card.tsx
@@ -72,4 +72,4 @@ function CardFooter({ className, ...props }: React.ComponentProps<'div'>) {
   );
 }
 
-export { Card, CardHeader, CardFooter, CardTitle, CardAction, CardDescription, CardContent };
+export { Card, CardAction, CardContent, CardDescription, CardFooter, CardHeader, CardTitle };

--- a/frontend/components/ui/checkbox.tsx
+++ b/frontend/components/ui/checkbox.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import * as React from 'react';
+
 import * as CheckboxPrimitive from '@radix-ui/react-checkbox';
 import { CheckIcon } from 'lucide-react';
 

--- a/frontend/components/ui/collapsible.tsx
+++ b/frontend/components/ui/collapsible.tsx
@@ -18,4 +18,4 @@ function CollapsibleContent({
   return <CollapsiblePrimitive.CollapsibleContent data-slot="collapsible-content" {...props} />;
 }
 
-export { Collapsible, CollapsibleTrigger, CollapsibleContent };
+export { Collapsible, CollapsibleContent, CollapsibleTrigger };

--- a/frontend/components/ui/dropdown-menu.tsx
+++ b/frontend/components/ui/dropdown-menu.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import * as React from 'react';
+
 import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu';
 import { CheckIcon, ChevronRightIcon, CircleIcon } from 'lucide-react';
 
@@ -208,18 +209,18 @@ function DropdownMenuSubContent({
 
 export {
   DropdownMenu,
-  DropdownMenuPortal,
-  DropdownMenuTrigger,
+  DropdownMenuCheckboxItem,
   DropdownMenuContent,
   DropdownMenuGroup,
-  DropdownMenuLabel,
   DropdownMenuItem,
-  DropdownMenuCheckboxItem,
+  DropdownMenuLabel,
+  DropdownMenuPortal,
   DropdownMenuRadioGroup,
   DropdownMenuRadioItem,
   DropdownMenuSeparator,
   DropdownMenuShortcut,
   DropdownMenuSub,
-  DropdownMenuSubTrigger,
   DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
 };

--- a/frontend/components/ui/field.tsx
+++ b/frontend/components/ui/field.tsx
@@ -1,11 +1,12 @@
 'use client';
 
 import { useMemo } from 'react';
+
 import { cva, type VariantProps } from 'class-variance-authority';
 
-import { cn } from '@/lib/utils';
 import { Label } from '@/components/ui/label';
 import { Separator } from '@/components/ui/separator';
+import { cn } from '@/lib/utils';
 
 function FieldSet({ className, ...props }: React.ComponentProps<'fieldset'>) {
   return (
@@ -222,13 +223,13 @@ function FieldError({
 
 export {
   Field,
-  FieldLabel,
+  FieldContent,
   FieldDescription,
   FieldError,
   FieldGroup,
+  FieldLabel,
   FieldLegend,
   FieldSeparator,
   FieldSet,
-  FieldContent,
   FieldTitle,
 };

--- a/frontend/components/ui/form.tsx
+++ b/frontend/components/ui/form.tsx
@@ -1,20 +1,21 @@
 'use client';
 
 import * as React from 'react';
-import * as LabelPrimitive from '@radix-ui/react-label';
-import { Slot } from '@radix-ui/react-slot';
 import {
   Controller,
-  FormProvider,
-  useFormContext,
-  useFormState,
   type ControllerProps,
   type FieldPath,
   type FieldValues,
+  FormProvider,
+  useFormContext,
+  useFormState,
 } from 'react-hook-form';
 
-import { cn } from '@/lib/utils';
+import * as LabelPrimitive from '@radix-ui/react-label';
+import { Slot } from '@radix-ui/react-slot';
+
 import { Label } from '@/components/ui/label';
+import { cn } from '@/lib/utils';
 
 const Form = FormProvider;
 
@@ -141,12 +142,12 @@ function FormMessage({ className, ...props }: React.ComponentProps<'p'>) {
 }
 
 export {
-  useFormField,
   Form,
-  FormItem,
-  FormLabel,
   FormControl,
   FormDescription,
-  FormMessage,
   FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+  useFormField,
 };

--- a/frontend/components/ui/input-group.tsx
+++ b/frontend/components/ui/input-group.tsx
@@ -1,12 +1,13 @@
 'use client';
 
 import * as React from 'react';
+
 import { cva, type VariantProps } from 'class-variance-authority';
 
-import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
+import { cn } from '@/lib/utils';
 
 function InputGroup({ className, ...props }: React.ComponentProps<'div'>) {
   return (
@@ -152,7 +153,7 @@ export {
   InputGroup,
   InputGroupAddon,
   InputGroupButton,
-  InputGroupText,
   InputGroupInput,
+  InputGroupText,
   InputGroupTextarea,
 };

--- a/frontend/components/ui/label.tsx
+++ b/frontend/components/ui/label.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import * as React from 'react';
+
 import * as LabelPrimitive from '@radix-ui/react-label';
 
 import { cn } from '@/lib/utils';

--- a/frontend/components/ui/pagination.tsx
+++ b/frontend/components/ui/pagination.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
 import Link from 'next/link';
+
 import { ChevronLeftIcon, ChevronRightIcon, MoreHorizontalIcon } from 'lucide-react';
 
-import { cn } from '@/lib/utils';
 import { Button, buttonVariants } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
 
 function Pagination({ className, ...props }: React.ComponentProps<'nav'>) {
   return (
@@ -99,9 +100,9 @@ function PaginationEllipsis({ className, ...props }: React.ComponentProps<'span'
 export {
   Pagination,
   PaginationContent,
-  PaginationLink,
-  PaginationItem,
-  PaginationPrevious,
-  PaginationNext,
   PaginationEllipsis,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
 };

--- a/frontend/components/ui/separator.tsx
+++ b/frontend/components/ui/separator.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import * as React from 'react';
+
 import * as SeparatorPrimitive from '@radix-ui/react-separator';
 
 import { cn } from '@/lib/utils';

--- a/frontend/components/ui/sheet.tsx
+++ b/frontend/components/ui/sheet.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import * as React from 'react';
+
 import * as SheetPrimitive from '@radix-ui/react-dialog';
 import { XIcon } from 'lucide-react';
 
@@ -120,11 +121,11 @@ function SheetDescription({
 
 export {
   Sheet,
-  SheetTrigger,
   SheetClose,
   SheetContent,
-  SheetHeader,
-  SheetFooter,
-  SheetTitle,
   SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
 };

--- a/frontend/components/ui/sidebar.tsx
+++ b/frontend/components/ui/sidebar.tsx
@@ -1,12 +1,11 @@
 'use client';
 
 import * as React from 'react';
+
 import { Slot } from '@radix-ui/react-slot';
 import { cva, type VariantProps } from 'class-variance-authority';
 import { PanelLeftIcon } from 'lucide-react';
 
-import { useIsMobile } from '@/hooks/use-mobile';
-import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Separator } from '@/components/ui/separator';
@@ -19,6 +18,8 @@ import {
 } from '@/components/ui/sheet';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import { useIsMobile } from '@/hooks/use-mobile';
+import { cn } from '@/lib/utils';
 
 const SIDEBAR_COOKIE_NAME = 'sidebar_state';
 const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;

--- a/frontend/components/ui/sonner.tsx
+++ b/frontend/components/ui/sonner.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { useTheme } from 'next-themes';
+
 import {
   CircleCheckIcon,
   InfoIcon,
@@ -7,7 +9,6 @@ import {
   OctagonXIcon,
   TriangleAlertIcon,
 } from 'lucide-react';
-import { useTheme } from 'next-themes';
 import { Toaster as Sonner, type ToasterProps } from 'sonner';
 
 const Toaster = ({ ...props }: ToasterProps) => {

--- a/frontend/components/ui/table.tsx
+++ b/frontend/components/ui/table.tsx
@@ -89,4 +89,4 @@ function TableCaption({ className, ...props }: React.ComponentProps<'caption'>) 
   );
 }
 
-export { Table, TableHeader, TableBody, TableFooter, TableHead, TableRow, TableCell, TableCaption };
+export { Table, TableBody, TableCaption, TableCell, TableFooter, TableHead, TableHeader, TableRow };

--- a/frontend/components/ui/tabs.tsx
+++ b/frontend/components/ui/tabs.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import * as React from 'react';
+
 import * as TabsPrimitive from '@radix-ui/react-tabs';
 
 import { cn } from '@/lib/utils';
@@ -52,4 +53,4 @@ const TabsContent = React.forwardRef<
 ));
 TabsContent.displayName = TabsPrimitive.Content.displayName;
 
-export { Tabs, TabsList, TabsTrigger, TabsContent };
+export { Tabs, TabsContent, TabsList, TabsTrigger };

--- a/frontend/components/ui/tooltip.tsx
+++ b/frontend/components/ui/tooltip.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import * as React from 'react';
+
 import * as TooltipPrimitive from '@radix-ui/react-tooltip';
 
 import { cn } from '@/lib/utils';
@@ -54,4 +55,4 @@ function TooltipContent({
   );
 }
 
-export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider };
+export { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger };

--- a/frontend/e2e/customer.pom.ts
+++ b/frontend/e2e/customer.pom.ts
@@ -1,4 +1,5 @@
-import { Page, expect } from '@playwright/test';
+import { expect, Page } from '@playwright/test';
+
 import {
   CreateCustomerFormData,
   UpdateCustomerFormData,

--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -2,6 +2,7 @@ import { defineConfig, globalIgnores } from "eslint/config";
 import nextVitals from "eslint-config-next/core-web-vitals";
 import nextTs from "eslint-config-next/typescript";
 import prettierConfig from "eslint-config-prettier";
+import simpleImportSort from "eslint-plugin-simple-import-sort";
 
 const eslintConfig = defineConfig([
   nextVitals,
@@ -29,7 +30,32 @@ const eslintConfig = defineConfig([
     'playwright-report/**',
   ]),
   {
+    plugins: {
+      "simple-import-sort": simpleImportSort,
+    },
     rules: {
+      "simple-import-sort/imports": [
+        "error",
+        {
+          groups: [
+            // 1. Framework: packages starting with `react` or `next`
+            ["^react", "^next"],
+            // 2. Externals: everything else
+            ["^@?\\w"],
+            // 3. Shared/Monorepo
+            ["^@sgcv2/shared"],
+            // 4. Aliases Internos (@/)
+            ["^@/"],
+            // 5. Features (@feature/)
+            ["^@feature/"],
+            // 6. Relatives
+            ["^\\.\\.(?!/?$)", "^\\.\\./?$", "^\\./(?=.*/)(?!/?$)", "^\\.(?!/?$)", "^\\./?$"],
+            // 7. Styles
+            ["^.+\\.s?css$"],
+          ],
+        },
+      ],
+      "simple-import-sort/exports": "error",
       '@typescript-eslint/no-explicit-any': 'error',
       '@typescript-eslint/no-restricted-types': [
         'error',

--- a/frontend/hooks/use-auth.ts
+++ b/frontend/hooks/use-auth.ts
@@ -1,5 +1,6 @@
-import { useAuthStore } from '@/stores/auth.store';
 import { useCallback } from 'react';
+
+import { useAuthStore } from '@/stores/auth.store';
 
 export function useAuth() {
   const {

--- a/frontend/lib/api/auth.service.ts
+++ b/frontend/lib/api/auth.service.ts
@@ -1,5 +1,6 @@
+import { AppResponse, AuthenticatedUserDto, LoginDto } from '@sgcv2/shared';
+
 import { apiClient } from './client';
-import { LoginDto, AppResponse, AuthenticatedUserDto } from '@sgcv2/shared';
 
 interface LoginResponse {
   user: AuthenticatedUserDto;

--- a/frontend/lib/api/customers.service.ts
+++ b/frontend/lib/api/customers.service.ts
@@ -1,6 +1,7 @@
-import { apiClient } from './client';
-import { CustomerDto as Customer, CreateCustomerDto, UpdateCustomerDto } from '@sgcv2/shared';
+import { CreateCustomerDto, CustomerDto as Customer, UpdateCustomerDto } from '@sgcv2/shared';
 import { AppResponse, CustomerState } from '@sgcv2/shared';
+
+import { apiClient } from './client';
 
 interface Filters {
   state?: CustomerState;

--- a/frontend/lib/api/server-client.ts
+++ b/frontend/lib/api/server-client.ts
@@ -1,5 +1,6 @@
-import axios from 'axios';
 import { cookies } from 'next/headers';
+
+import axios from 'axios';
 
 /**
  * Server-side API client for use in Server Components and Server Actions

--- a/frontend/lib/api/server-customers.service.ts
+++ b/frontend/lib/api/server-customers.service.ts
@@ -1,11 +1,13 @@
-import { createServerApiClient } from './server-client';
+import { AxiosError } from 'axios';
+
 import {
-  CustomerDto as Customer,
   AppResponse,
   CreateCustomerDto,
+  CustomerDto as Customer,
   UpdateCustomerDto,
 } from '@sgcv2/shared';
-import { AxiosError } from 'axios';
+
+import { createServerApiClient } from './server-client';
 
 /**
  * Server-side customers service for use in Server Components

--- a/frontend/lib/api/server-locations.service.ts
+++ b/frontend/lib/api/server-locations.service.ts
@@ -1,11 +1,13 @@
-import { createServerApiClient } from './server-client';
+import { AxiosError } from 'axios';
+
 import {
-  CustomerLocationDto as CustomerLocation,
   AppResponse,
   CreateCustomerLocationDto,
+  CustomerLocationDto as CustomerLocation,
   UpdateCustomerLocationDto,
 } from '@sgcv2/shared';
-import { AxiosError } from 'axios';
+
+import { createServerApiClient } from './server-client';
 
 /**
  * Server-side locations service for use in Server Components

--- a/frontend/lib/api/server-permissions.service.ts
+++ b/frontend/lib/api/server-permissions.service.ts
@@ -1,4 +1,5 @@
 import { AppResponse, PermissionDto } from '@sgcv2/shared';
+
 import { createServerApiClient } from './server-client';
 
 export const serverPermissionsService = {

--- a/frontend/lib/api/server-roles.service.ts
+++ b/frontend/lib/api/server-roles.service.ts
@@ -1,12 +1,13 @@
 import {
   AppResponse,
+  CreateRoleDto,
+  PermissionDto,
   RoleDto,
   RoleFilterDto,
-  CreateRoleDto,
-  UpdateRoleDto,
-  PermissionDto,
   RoleWithPermissionsDto,
+  UpdateRoleDto,
 } from '@sgcv2/shared';
+
 import { createServerApiClient } from './server-client';
 
 export const serverRolesService = {

--- a/frontend/lib/api/server-subcustomers.service.ts
+++ b/frontend/lib/api/server-subcustomers.service.ts
@@ -1,11 +1,13 @@
-import { createServerApiClient } from './server-client';
+import { AxiosError } from 'axios';
+
 import {
-  SubCustomerDto as SubCustomer,
   AppResponse,
   CreateSubCustomerDto,
+  SubCustomerDto as SubCustomer,
   UpdateSubCustomerDto,
 } from '@sgcv2/shared';
-import { AxiosError } from 'axios';
+
+import { createServerApiClient } from './server-client';
 
 /**
  * Server-side sub-customers service for use in Server Components

--- a/frontend/lib/api/server-users.service.ts
+++ b/frontend/lib/api/server-users.service.ts
@@ -1,11 +1,12 @@
 import {
   AppResponse,
-  UserWithRolesDto,
-  UpdateUserDto,
-  UserFilterDto,
-  UserDto,
   CreateUserDto,
+  UpdateUserDto,
+  UserDto,
+  UserFilterDto,
+  UserWithRolesDto,
 } from '@sgcv2/shared';
+
 import { createServerApiClient } from './server-client';
 
 export const serverUsersService = {

--- a/frontend/lib/api/users.service.ts
+++ b/frontend/lib/api/users.service.ts
@@ -1,11 +1,12 @@
 import {
   AppResponse,
-  UserWithRolesDto,
+  CreateUserDto,
   UpdateUserDto,
   UserDto,
-  CreateUserDto,
   UserFilterDto,
+  UserWithRolesDto,
 } from '@sgcv2/shared';
+
 import { apiClient } from './client';
 
 export const usersService = {

--- a/frontend/lib/utils.ts
+++ b/frontend/lib/utils.ts
@@ -1,4 +1,4 @@
-import { clsx, type ClassValue } from 'clsx';
+import { type ClassValue, clsx } from 'clsx';
 import { twMerge } from 'tailwind-merge';
 
 export function cn(...inputs: ClassValue[]) {

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -1,5 +1,5 @@
-import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
 
 // Routes that don't require authentication
 const publicRoutes = ['/login'];

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -60,6 +60,7 @@
     "eslint-config-next": "16.0.3",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.4",
+    "eslint-plugin-simple-import-sort": "^12.1.1",
     "jest-environment-jsdom": "^30.2.0",
     "prettier": "^3.7.4",
     "tailwindcss": "^4",

--- a/frontend/stores/auth.store.ts
+++ b/frontend/stores/auth.store.ts
@@ -1,9 +1,11 @@
-import { authService } from '@/lib/api/auth.service';
-import { usersService } from '@/lib/api/users.service';
-import { AuthenticatedUserDto } from '@sgcv2/shared';
+import { sha256 } from 'js-sha256';
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
-import { sha256 } from 'js-sha256';
+
+import { AuthenticatedUserDto } from '@sgcv2/shared';
+
+import { authService } from '@/lib/api/auth.service';
+import { usersService } from '@/lib/api/users.service';
 
 interface AuthState {
   user: AuthenticatedUserDto | null;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -320,6 +320,9 @@ importers:
       eslint-plugin-prettier:
         specifier: ^5.5.4
         version: 5.5.5(eslint-config-prettier@10.1.8(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))(prettier@3.8.1)
+      eslint-plugin-simple-import-sort:
+        specifier: ^12.1.1
+        version: 12.1.1(eslint@9.39.2(jiti@2.6.1))
       jest-environment-jsdom:
         specifier: ^30.2.0
         version: 30.2.0
@@ -2808,6 +2811,11 @@ packages:
     engines: {node: '>=4'}
     peerDependencies:
       eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7
+
+  eslint-plugin-simple-import-sort@12.1.1:
+    resolution: {integrity: sha512-6nuzu4xwQtE3332Uz0to+TxDQYRLTKRESSc2hefVT48Zc8JthmN23Gx9lnYhu0FtkRSL1oxny3kJ2aveVhmOVA==}
+    peerDependencies:
+      eslint: '>=5.0.0'
 
   eslint-scope@8.4.0:
     resolution: {integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==}
@@ -7904,6 +7912,10 @@ snapshots:
       semver: 6.3.1
       string.prototype.matchall: 4.0.12
       string.prototype.repeat: 1.0.0
+
+  eslint-plugin-simple-import-sort@12.1.1(eslint@9.39.2(jiti@2.6.1)):
+    dependencies:
+      eslint: 9.39.2(jiti@2.6.1)
 
   eslint-scope@8.4.0:
     dependencies:


### PR DESCRIPTION
## Descripción
Esta PR implementa la ordenación automática de los imports en el frontend utilizando `eslint-plugin-simple-import-sort`.

## Cambios
- Adición de `eslint-plugin-simple-import-sort` como dependencia de desarrollo.
- Configuración de reglas en `eslint.config.mjs` para establecer una jerarquía de imports:
  1. Framework (React, Next)
  2. Librerías externas
  3. Shared Monorepo (@sgcv2/shared)
  4. Aliases Internos (@/)
  5. Feature Aliases (@feature/)
  6. Imports Relativos
  7. Estilos e Imágenes
- Refactorización automática de todos los archivos del frontend para cumplir con el nuevo estándar.

## Beneficios
- Mejora la legibilidad del código.
- Evita inconsistencias y desorden en archivos grandes.
- Automatiza una tarea manual mediante el linting.